### PR TITLE
Add profiling scripts and CI for Datason benchmarks

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -1,0 +1,80 @@
+name: "🔥 Profiling"
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  profiling:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        with_rust: [off, on]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Profile stage timings
+        run: |
+          python scripts/profile_stages.py --with-rust ${{ matrix.with_rust }}
+
+      - name: Generate flamegraph
+        run: |
+          bash scripts/profile_flame_pyspy.sh ${{ matrix.with_rust }}
+
+      - name: Upload profiling artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: profiling-${{ matrix.with_rust }}
+          path: |
+            results/stage_times_${{ matrix.with_rust }}.json
+            results/stage_times_${{ matrix.with_rust }}.csv
+            results/flame_${{ matrix.with_rust }}.svg
+          if-no-files-found: ignore
+
+      - name: Comment summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          WITH_RUST: ${{ matrix.with_rust }}
+        with:
+          script: |
+            const fs = require('fs');
+            const withRust = process.env.WITH_RUST;
+            const file = `results/stage_times_${withRust}.json`;
+            if (!fs.existsSync(file)) {
+              return;
+            }
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const stats = [];
+            for (const [scenario, stages] of Object.entries(data)) {
+              for (const [stage, s] of Object.entries(stages)) {
+                stats.push({name: `${scenario}:${stage}`, median: s.median});
+              }
+            }
+            stats.sort((a,b)=>b.median-a.median);
+            const top = stats.slice(0,5).map(s=>`- ${s.name}: ${s.median.toFixed(6)}s`).join('\n');
+            const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `### Profiling (${withRust})\n${top}\n[Flamegraph & artifacts](${runUrl})`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ Thumbs.db
 tmp/
 temp/
 pr_comment.md
+results/
 
 # Large data files (use Git LFS if needed)
 *.parquet
@@ -187,4 +188,5 @@ data/synthetic/*_data.json
 data/synthetic/generation_summary.json
 
 # Keep the data generator script but not generated data
-!data/synthetic/data_generator.py 
+!data/synthetic/data_generator.py
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ pandas>=2.0.0
 # Performance profiling and analysis
 memory-profiler>=0.61.0
 psutil>=5.9.0
+py-spy>=0.3.14
+scalene>=1.5.30
 
 # Data generation and testing
 faker>=19.0.0
@@ -34,4 +36,4 @@ requests>=2.31.0
 # tensorflow>=2.13.0
 
 # Development and testing
-pytest>=7.4.0 
+pytest>=7.4.0

--- a/scripts/bench_rust_core.py
+++ b/scripts/bench_rust_core.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Minimal workload used for py-spy flamegraph generation.
+
+This script repeatedly serializes and deserializes a sample payload to
+exercise the core engine.  The ``--with-rust`` flag toggles optional
+Rust acceleration to showcase performance differences in the flamegraphs.
+"""
+import argparse
+import os
+import datason
+
+
+def build_payload() -> dict:
+    """Create a moderately sized payload for profiling."""
+    return {"numbers": list(range(1000)), "text": "x" * 1024}
+
+
+def run(with_rust: bool, iterations: int) -> None:
+    """Execute the workload with optional Rust acceleration."""
+    os.environ["DATASON_RUST"] = "1" if with_rust else "0"
+    payload = build_payload()
+    for _ in range(iterations):
+        data = datason.dumps(payload)
+        datason.load_basic(data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Datason core workload for profiling")
+    parser.add_argument("--with-rust", choices=["on", "off"], default="on")
+    parser.add_argument("--iterations", type=int, default=100)
+    args = parser.parse_args()
+    run(args.with_rust == "on", args.iterations)
+

--- a/scripts/profile_flame_pyspy.sh
+++ b/scripts/profile_flame_pyspy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Generate flamegraphs using py-spy for Datason with and without Rust.
+set -euo pipefail
+MODE=${1:-both}
+mkdir -p results
+if [[ "$MODE" == "off" || "$MODE" == "both" ]]; then
+  py-spy record -o results/flame_off.svg -- python scripts/bench_rust_core.py --with-rust off
+fi
+if [[ "$MODE" == "on" || "$MODE" == "both" ]]; then
+  py-spy record -o results/flame_on.svg --native -- python scripts/bench_rust_core.py --with-rust on
+fi
+

--- a/scripts/profile_scalene.sh
+++ b/scripts/profile_scalene.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Optional scalene run for per-line profiling.
+set -euo pipefail
+mkdir -p results
+python -m scalene --outfile results/scalene_report.txt scripts/bench_rust_core.py --with-rust off
+

--- a/scripts/profile_stages.py
+++ b/scripts/profile_stages.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Collect per-stage timing information for Datason operations.
+
+The script generates payloads of various sizes and structures, toggles
+`DATASON_PROFILE`, and records serialization/deserialization times.  The
+results are aggregated into median and 95th percentile statistics and
+written to JSON and CSV files under ``results/``.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import datason
+
+
+def generate_payload(size: int, kind: str) -> dict:
+    """Generate synthetic payloads of approximately ``size`` bytes."""
+    blob = "x" * size
+    if kind == "flat":
+        return {f"k{i}": blob for i in range(1)}
+    if kind == "nested":
+        return {"level1": {"level2": {"data": blob}}}
+    # mixed
+    return {"list": [blob, blob], "dict": {"a": blob, "b": blob}}
+
+
+def measure(data: dict, iterations: int) -> Dict[str, List[float]]:
+    """Measure serialization and deserialization times."""
+    serialize: List[float] = []
+    deserialize: List[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        dumped = datason.dumps(data)
+        serialize.append(time.perf_counter() - start)
+        start = time.perf_counter()
+        datason.load_basic(dumped)
+        deserialize.append(time.perf_counter() - start)
+    return {"serialize": serialize, "deserialize": deserialize}
+
+
+def aggregate(stage_times: Dict[str, List[float]]) -> Dict[str, Dict[str, float]]:
+    """Aggregate stage timings into median and p95 statistics."""
+    results: Dict[str, Dict[str, float]] = {}
+    for stage, values in stage_times.items():
+        if not values:
+            continue
+        p95 = statistics.quantiles(values, n=100)[94] if len(values) > 1 else values[0]
+        results[stage] = {
+            "median": statistics.median(values),
+            "p95": p95,
+        }
+    return results
+
+
+def profile(with_rust: bool, iterations: int, output_dir: Path) -> None:
+    os.environ["DATASON_PROFILE"] = "1"
+    os.environ["DATASON_RUST"] = "1" if with_rust else "0"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sizes = [10_000, 100_000, 1_000_000]
+    structures = ["flat", "nested", "mixed"]
+
+    aggregated: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for size in sizes:
+        for struct in structures:
+            payload = generate_payload(size, struct)
+            timings = measure(payload, iterations)
+            aggregated[f"{struct}_{size}"] = aggregate(timings)
+
+    suffix = "on" if with_rust else "off"
+    json_path = output_dir / f"stage_times_{suffix}.json"
+    csv_path = output_dir / f"stage_times_{suffix}.csv"
+
+    with json_path.open("w") as jf:
+        json.dump(aggregated, jf, indent=2)
+    with csv_path.open("w", newline="") as cf:
+        writer = csv.writer(cf)
+        writer.writerow(["scenario", "stage", "median", "p95"])
+        for scenario, stages in aggregated.items():
+            for stage, stats in stages.items():
+                writer.writerow([
+                    scenario,
+                    stage,
+                    f"{stats['median']:.6f}",
+                    f"{stats['p95']:.6f}",
+                ])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Profile Datason stage timings")
+    parser.add_argument("--with-rust", choices=["on", "off"], default="off")
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--output-dir", default="results")
+    args = parser.parse_args()
+    profile(args.with_rust == "on", args.iterations, Path(args.output_dir))
+


### PR DESCRIPTION
## Summary
- add py-spy and scalene dev dependencies
- ignore profiling artifacts in git
- introduce profiling scripts for stage timings and flamegraphs
- add optional scalene and core workload scripts
- run profiling in new GitHub Actions workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f523e0660832595593c0f39673f36