### PR TITLE
fix: Resolve f-string syntax error in test_workflow_integration.py

### DIFF
--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -492,12 +492,14 @@ def run_workflow_integration_tests():
         if result.failures:
             print("\nFailures:")
             for test, traceback in result.failures:
-                print(f"  - {test}: {traceback.split('AssertionError: ')[-1].split('\\n')[0]}")
+                error_msg = traceback.split('AssertionError: ')[-1].split('\n')[0]
+                print(f"  - {test}: {error_msg}")
         
         if result.errors:
             print("\nErrors:")  
             for test, traceback in result.errors:
-                print(f"  - {test}: {traceback.split('\\n')[-2]}")
+                error_msg = traceback.split('\n')[-2]
+                print(f"  - {test}: {error_msg}")
     
     return result.wasSuccessful()
 


### PR DESCRIPTION
## Problem
The CI validation tests were failing with a Python syntax error:
```
f-string expression part cannot include a backslash
```

This occurred on lines 495 and 501 in `test_workflow_integration.py` where f-string expressions contained backslashes, which is not allowed in Python.

## Solution
Fixed by extracting string operations with backslashes outside the f-string expressions:

**Before:**
```python
print(f"  - {test}: {traceback.split('AssertionError: ')[-1].split('\\n')[0]}")
```

**After:**
```python
error_msg = traceback.split('AssertionError: ')[-1].split('\n')[0]
print(f"  - {test}: {error_msg}")
```

## Testing
- ✅ Python syntax validation passes
- ✅ pytest can collect all 15 tests without errors  
- ✅ String operations work correctly with expected output

## Impact
This fixes the CI test collection error and allows the comprehensive validation tests to run properly, ensuring the branch protection works as intended.

🤖 Generated with [Claude Code](https://claude.ai/code)