### PR TITLE
feat: add scenario names to regression analysis tables

### DIFF
--- a/scripts/regression_detector.py
+++ b/scripts/regression_detector.py
@@ -201,8 +201,9 @@ class PerformanceRegressionDetector:
                                 # Extract DataSON serialization metrics
                                 datason_ser = dataset_data['serialization']['datason']
                                 if 'mean' in datason_ser:
-                                    metrics['serialize_time'] = PerformanceMetric(
-                                        name='serialize_time',
+                                    serialize_metric_name = f"{dataset_name}_serialize_time"
+                                    metrics[serialize_metric_name] = PerformanceMetric(
+                                        name=serialize_metric_name,
                                         value=datason_ser['mean'],
                                         unit='seconds',
                                         higher_is_better=False
@@ -212,8 +213,9 @@ class PerformanceRegressionDetector:
                                 if 'deserialization' in dataset_data and 'datason' in dataset_data['deserialization']:
                                     datason_deser = dataset_data['deserialization']['datason']
                                     if 'mean' in datason_deser:
-                                        metrics['deserialize_time'] = PerformanceMetric(
-                                            name='deserialize_time',
+                                        deserialize_metric_name = f"{dataset_name}_deserialize_time"
+                                        metrics[deserialize_metric_name] = PerformanceMetric(
+                                            name=deserialize_metric_name,
                                             value=datason_deser['mean'],
                                             unit='seconds',
                                             higher_is_better=False
@@ -236,8 +238,9 @@ class PerformanceRegressionDetector:
                         # Extract DataSON serialization metrics
                         datason_ser = dataset_data['serialization']['datason']
                         if 'mean' in datason_ser:
-                            metrics['serialize_time'] = PerformanceMetric(
-                                name='serialize_time',
+                            serialize_metric_name = f"{dataset_name}_serialize_time"
+                            metrics[serialize_metric_name] = PerformanceMetric(
+                                name=serialize_metric_name,
                                 value=datason_ser['mean'],
                                 unit='seconds',
                                 higher_is_better=False
@@ -247,8 +250,9 @@ class PerformanceRegressionDetector:
                         if 'deserialization' in dataset_data and 'datason' in dataset_data['deserialization']:
                             datason_deser = dataset_data['deserialization']['datason']
                             if 'mean' in datason_deser:
-                                metrics['deserialize_time'] = PerformanceMetric(
-                                    name='deserialize_time',
+                                deserialize_metric_name = f"{dataset_name}_deserialize_time"
+                                metrics[deserialize_metric_name] = PerformanceMetric(
+                                    name=deserialize_metric_name,
                                     value=datason_deser['mean'],
                                     unit='seconds',
                                     higher_is_better=False


### PR DESCRIPTION
The regression detector now includes test scenario names in metric identifiers, making the analysis tables much clearer and more actionable.

Changes:
- Metric names now include scenario context (e.g., "api_response_serialize_time")
- Eliminates confusing duplicate "serialize_time" entries without context
- Makes it easier to identify which specific test scenarios have regressions
- Applies to both new tiered format and legacy competitive format

Example improvement:
Before: serialize_time, serialize_time, deserialize_time After: api_response_serialize_time, simple_objects_serialize_time, api_response_deserialize_time

🤖 Generated with [Claude Code](https://claude.ai/code)